### PR TITLE
remove perlbug e-mail

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -36,7 +36,6 @@ WriteMakefile(
             },
             homepage    => 'https://metacpan.org/module/Email-IsEmail',
             bugtracker  => {
-                mailto      => 'perlbug@perl.org',
                 web         => "https://rt.cpan.org/NoAuth/ReportBug.html?Queue=Email-IsEmail",
             },
         },


### PR DESCRIPTION
perbug e-mail is for reporting bugs in perl itself
